### PR TITLE
Add multiple test target os versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,9 @@ language: objective-c
 os: osx
 sudo: enabled
 
-branches:
-  only:
-    - master
+osx_image: xcode9.2
 
 xcode_workspace: Generika.xcworkspace
-xcode_scheme: GenerikaTests
-osx_image: xcode9.2
 
 podfile: Podfile
 
@@ -19,8 +15,26 @@ before_install:
 install:
   - bundle exec pod install
 
+matrix:
+  include:
+    - xcode_scheme: GenerikaTests
+      xcode_sdk: iphonesimulator11.2
+      env: OS_VERSION=11.2
+
+    - xcode_scheme: GenerikaTests
+      xcode_sdk: iphonesimulator10.3.1
+      env: OS_VERSION=10.3.1
+
+    - xcode_scheme: GenerikaTests
+      xcode_sdk: iphonesimulator9.3
+      env: OS_VERSION=9.3
+
 script:
-  - make test
+  - OS_VERSION=$OS_VERSION make test
+
+branches:
+  only:
+    - master
 
 notifications:
   email:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 # -- testing
+ifeq (, $(OS_VERSION))
+	OS_VERSION=latest
+endif
 
 test:
-	./bin/test-runner All
+	OS_VERSION=$(OS_VERSION) ./bin/test-runner All
 .PHONY: test
 
 .DEFAULT_GOAL = test

--- a/README.md
+++ b/README.md
@@ -128,15 +128,21 @@ ZBarSDK
 
 ## Test
 
-Run [XCTest](https://developer.apple.com/documentation/xctest?language=objc)
+Run [XCTest](https://developer.apple.com/documentation/xctest?language=objc).
+
+`test-runner` script supports multiple versions of _iphonesimulator_.
 
 ```zsh
-# same as ./bin/test-runner All, see `test-runner` script
+# same as OS_VERSION="latest" ./bin/test-runner All, see `test-runner` script
 % make test
+% OS_VERSION="10.3.1" make test
 
 # run single test case
-% ./bin/test-runner ProductTest/testInit
+% OS_VERSION="latest" ./bin/test-runner ProductTest/testInit
+% OS_VERSION="10.3.1" ./bin/test-runner ProductTest/testInit
 ```
+
+About target versions, see also _matrix_ in `.travis.yml`.
 
 
 ## Licence

--- a/bin/test-runner
+++ b/bin/test-runner
@@ -14,9 +14,9 @@ Arguments:
   <target>    test target (through only-testing) [optional]
 
 Examples:
-  $ test-runner All
-  $ test-runner ProductTests
-  $ test-runner ProductTests/testInit
+  $ OS_VERSION="latest" test-runner All
+  $ OS_VERSION="11.2" test-runner ProductTests
+  $ OS_VERSION="11.2" test-runner ProductTests/testInit
 USG
 }
 
@@ -26,7 +26,12 @@ function run_test() {
   platform="iOS Simulator"
   name="iPhone 6"
   sdk="iphonesimulator"
-  os="11.2"
+  if [ "${OS_VERSION}" == "" || "${OS_VERSION}" == "latest" ]; then
+    # set latest version
+    os="11.2"
+  else
+    os="${OS_VERSION}"
+  fi
 
   destination="platform=${platform},name=${name},OS=${os}"
 


### PR DESCRIPTION
Add more test target os versions

- iOS 11.2 (latest)
- iOS 10.3.1
- iOS 9.3

\# this pull request is `master` to `master`. it contains only change about multiple test target os(s).