### PR TITLE
Make prescription as single scroll target

### DIFF
--- a/Generika/AmkViewController.h
+++ b/Generika/AmkViewController.h
@@ -6,9 +6,11 @@
 //
 
 #import "Receipt.h"
+#import "MasterViewController.h"
 
 @interface AmkViewController : UIViewController <UIActionSheetDelegate>
 
+@property (nonatomic, strong, readwrite) MasterViewController *parent;
 @property (nonatomic, strong, readonly) Receipt *receipt;
 
 - (void)loadReceipt:(Receipt *)receipt;

--- a/Generika/Receipt.h
+++ b/Generika/Receipt.h
@@ -35,8 +35,8 @@
 @property (nonatomic, strong, readwrite) NSString *identifier;
 @property (nonatomic, strong, readwrite) NSString *givenName;
 @property (nonatomic, strong, readwrite) NSString *familyName;
-@property (nonatomic, assign) int weight;
-@property (nonatomic, assign) int height;
+@property (nonatomic, strong, readwrite) NSString *weight;
+@property (nonatomic, strong, readwrite) NSString *height;
 @property (nonatomic, strong, readwrite) NSString *birthDate;
 @property (nonatomic, strong, readwrite) NSString *gender;
 
@@ -73,6 +73,7 @@
 + (NSDictionary *)rereiptKeyMaps;
 + (id)importFromDict:(NSDictionary *)dict;
 
+- (NSInteger)entriesCountOfField:(NSString *)field;
 - (NSArray *)receiptKeys;
 
 @end

--- a/Generika/Receipt.m
+++ b/Generika/Receipt.m
@@ -355,6 +355,33 @@
   }
 }
 
+- (NSInteger)entriesCountOfField:(NSString *)field
+{
+  NSInteger count = 0;
+  if ([field isEqualToString:@"operator"]) {
+    Operator *operator = self.operator;
+    if (operator) {
+      for (NSString *key in [operator operatorKeys]) {
+        NSString *value = [operator valueForKey:key];
+        if (value && ![value isEqualToString:@""]) {
+          count += 1;
+        }
+      }
+    }
+  } else if ([field isEqualToString:@"patient"]) {
+    Patient *patient = self.patient;
+    if (patient) {
+      for (NSString *key in [patient patientKeys]) {
+        NSString *value = [patient valueForKey:key];
+        if (value && ![value isEqualToString:@""]) {
+          count += 1;
+        }
+      }
+    }
+  }
+  return count;
+}
+
 #pragma mark - Conversion to Dictionary
 
 - (NSArray *)receiptKeys


### PR DESCRIPTION
Make prescription detail view as single scroll target. Each section (`Arzt` and `Patient`) height extends by entries count from imported Prescription JSON.

## NOTE

Thins, what I do not yet :)

* This change has still unnecessary margins under sections `Artzt` and `Patient`.
* Some entries (z.B. `email_address`, `weight_kg` and `gender`) are still not there.
* iPhone X may have still strange margin (I don't check that on iPhone X's simulator)
* Prescription List View is still temporary (There are just temporary 2 labels there).

## Screenshots

![simulator screen shot - iphone 6 - 2018-01-09 at 07 01 35](https://user-images.githubusercontent.com/163063/34694679-49f4f62c-f50b-11e7-93b3-f97e7f519e1d.png)
![simulator screen shot - iphone 6 - 2018-01-09 at 07 01 43](https://user-images.githubusercontent.com/163063/34694656-3cf556ce-f50b-11e7-807d-a23c26e1054d.png)
![simulator screen shot - iphone 6 - 2018-01-09 at 07 01 55](https://user-images.githubusercontent.com/163063/34694670-45180cd4-f50b-11e7-9a59-92bd13ed01af.png)


\# this pull request is just notification marked as merge ready