### PR TITLE
Update receipt importing and view labels

### DIFF
--- a/Generika/Generika-Prefix.pch
+++ b/Generika/Generika-Prefix.pch
@@ -10,6 +10,10 @@
   #import "Constant.h"
 #endif
 
+#define deviceOrientation [[UIDevice currentDevice] orientation]
+#define isPortrait  UIDeviceOrientationIsPortrait(deviceOrientation)
+#define isLandscape UIDeviceOrientationIsLandscape(deviceOrientation)
+
 #ifdef DEBUG
   // usage: DLog(@"%@", object);
   #define DLog(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);

--- a/Generika/MasterViewController.h
+++ b/Generika/MasterViewController.h
@@ -15,6 +15,7 @@
 
 @interface MasterViewController : UITableViewController <
   ZBarReaderDelegate,
+  UIDocumentPickerDelegate,
   UISearchDisplayDelegate,
   UISearchBarDelegate,
   UIPopoverControllerDelegate>

--- a/Generika/MasterViewController.m
+++ b/Generika/MasterViewController.m
@@ -259,7 +259,10 @@ static const int kSegmentReceipt = 1;
 
 - (void)didRotate:(NSNotification *)notification
 {
-  // pass
+  // redraw via reload
+  [self.itemsView performSelectorOnMainThread:@selector(reloadData)
+                                   withObject:nil
+                                waitUntilDone:YES];
 }
 
 // iOS <= 5
@@ -642,7 +645,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
   } else {
     NSDate *now = [NSDate date];
     NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
-    [dateFormat setDateFormat:@"HH:mm dd.MM.YY"];
+    [dateFormat setDateFormat:@"HH:mm dd.MM.YYYY"];
     NSString *datetime = [dateFormat stringFromDate:now];
     ProductManager *manager = [ProductManager sharedManager];
 
@@ -835,7 +838,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
   cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
 
   UIView *itemView = [[UIView alloc] initWithFrame:CGRectMake(
-      0.0, 0.0, cellFrame.size.width, cellFrame.size.height)];
+    0.0, 0.0, cellFrame.size.width, cellFrame.size.height)];
   [cell.contentView addSubview:itemView];
 
   // build cell
@@ -849,7 +852,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
     // place date
     if (![receipt.placeDate isEqualToString:@""]) {
       UILabel *placeDateLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-          12.0, 8.0, itemView.frame.size.width - 24.0, 14.0)];
+        7.2, 8.0, itemView.frame.size.width - 23.0, 14.0)];
       placeDateLabel.font = [UIFont boldSystemFontOfSize:13.0];
       placeDateLabel.textAlignment = kTextAlignmentLeft;
       placeDateLabel.textColor = [UIColor blackColor];
@@ -862,20 +865,34 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
     CGFloat width = CGRectGetMaxX(tableView.frame) -
       CGRectGetMinX(tableView.frame);
     if (operator) {
-      // given_name + family_name
+      // title + given_name + family_name
       UILabel *nameLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-          12.0, 26.5, 178.0, 14.0)];
-      nameLabel.font = [UIFont systemFontOfSize:12.0];
+        7.2, 26.5, 168.0, 14.0)];
+      if (isLandscape) {
+        CGRect nameFrame = nameLabel.frame;
+        nameFrame.size.width = 222.0;
+        [nameLabel setFrame:nameFrame];
+      }
+      nameLabel.font = [UIFont systemFontOfSize:11.5];
       nameLabel.textAlignment = kTextAlignmentLeft;
       nameLabel.textColor = [UIColor blackColor];
       nameLabel.backgroundColor = [UIColor clearColor];
       nameLabel.text = [NSString stringWithFormat:@"%@ %@",
         operator.givenName, operator.familyName, nil];
+      if (![operator.title isEqualToString:@""]) {
+        nameLabel.text = [operator.title stringByAppendingString:[
+          NSString stringWithFormat:@" %@", nameLabel.text]];
+      }
       [cell.contentView addSubview:nameLabel];
       // phone
       UILabel *phoneLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-          12.0, 44.5, 178.0, 14.0)];
-      phoneLabel.font = [UIFont systemFontOfSize:12.0];
+        7.2, 44.5, 168.0, 14.0)];
+      if (isLandscape) {
+        CGRect phoneFrame = phoneLabel.frame;
+        phoneFrame.size.width = 222.0;
+        [phoneLabel setFrame:phoneFrame];
+      }
+      phoneLabel.font = [UIFont systemFontOfSize:11.5];
       phoneLabel.textAlignment = kTextAlignmentLeft;
       phoneLabel.textColor = [UIColor blackColor];
       phoneLabel.backgroundColor = [UIColor clearColor];
@@ -883,35 +900,71 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
       [cell.contentView addSubview:phoneLabel];
       // email
       UILabel *emailLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-          12.0, 61.0, itemView.frame.size.width - 24.0, 14.0)];
-      emailLabel.font = [UIFont systemFontOfSize:12.0];
+        7.2, 61.0, 168.0, 14.0)];
+      if (isLandscape) {
+        CGRect emailFrame = emailLabel.frame;
+        emailFrame.size.width = 222.0;
+        [emailLabel setFrame:emailFrame];
+      }
+      emailLabel.font = [UIFont systemFontOfSize:11.5];
       emailLabel.textAlignment = kTextAlignmentLeft;
       emailLabel.textColor = [UIColor blackColor];
       emailLabel.backgroundColor = [UIColor clearColor];
       emailLabel.text = operator.email;
       [cell.contentView addSubview:emailLabel];
     }
+    // original filename
+    if (![receipt.filename isEqualToString:@""]) {
+      UILabel *filenameLabel = [[UILabel alloc] initWithFrame:CGRectMake(
+        174.5, 27.0, 118.0, 14.0)];
+      if (isLandscape) {
+        CGRect filenameFrame = filenameLabel.frame;
+        filenameFrame.origin.x = 237.0;
+        filenameFrame.size.width = 258.0;
+        [filenameLabel setFrame:filenameFrame];
+      }
+      filenameLabel.font = [UIFont systemFontOfSize:10.5];
+      filenameLabel.textAlignment = kTextAlignmentLeft;
+      filenameLabel.textColor = [UIColor grayColor];
+      filenameLabel.backgroundColor = [UIColor clearColor];
+      filenameLabel.text = [receipt.filename lastPathComponent];
+      [cell.contentView addSubview:filenameLabel];
+    }
     // datetime (imported at)
-    if (![receipt.datetime isEqualToString:@""]) {
-      UILabel *datetimeLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-          198.0, 27, 123.0, 14.0)];
-      datetimeLabel.font = [UIFont systemFontOfSize:12.0];
-      datetimeLabel.textAlignment = kTextAlignmentLeft;
-      datetimeLabel.textColor = [UIColor grayColor];
-      datetimeLabel.text = receipt.datetime;
-      [cell.contentView addSubview:datetimeLabel];
+    UILabel *datetimeLabel = [[UILabel alloc] initWithFrame:CGRectMake(
+      174.5, 45.0, 118.0, 14.0)];
+    if (isLandscape) {
+      CGRect datetimeFrame = datetimeLabel.frame;
+      datetimeFrame.origin.x = 237.0;
+      datetimeFrame.size.width = 258.0;
+      [datetimeLabel setFrame:datetimeFrame];
     }
+    datetimeLabel.font = [UIFont systemFontOfSize:10.5];
+    datetimeLabel.textAlignment = kTextAlignmentLeft;
+    datetimeLabel.textColor = [UIColor grayColor];
+    datetimeLabel.backgroundColor = [UIColor clearColor];
+    datetimeLabel.text = receipt.importedAt;
+    [cell.contentView addSubview:datetimeLabel];
     // medications
-    if ([receipt.products count] > 0) {
-      UILabel *productsLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-          198.5, 45, 123.0, 14.0)];
-      productsLabel.font = [UIFont systemFontOfSize:11.0];
-      productsLabel.textAlignment = kTextAlignmentLeft;
-      productsLabel.textColor = [UIColor grayColor];
-      productsLabel.text = [NSString stringWithFormat:@"%d Medikamente",
-        [receipt.products count], nil];
-      [cell.contentView addSubview:productsLabel];
+    UILabel *productsLabel = [[UILabel alloc] initWithFrame:CGRectMake(
+      175.0, 61.0, 118.0, 14.0)];
+    if (isLandscape) {
+      CGRect productsFrame = productsLabel.frame;
+      productsFrame.origin.x = 237.0;
+      productsFrame.size.width = 258.0;
+      [productsLabel setFrame:productsFrame];
     }
+    productsLabel.font = [UIFont systemFontOfSize:10.5];
+    productsLabel.textAlignment = kTextAlignmentLeft;
+    productsLabel.textColor = [UIColor grayColor];
+    productsLabel.backgroundColor = [UIColor clearColor];
+    NSInteger count = [receipt.products count];
+    NSString *format = @"%d Medikamente";
+    if (count < 2) {
+      format = @"%d Medikament";
+    }
+    productsLabel.text = [NSString stringWithFormat:format, count, nil];
+    [cell.contentView addSubview:productsLabel];
   } else {  // product
     // gesture
     UILongPressGestureRecognizer *longPressGesture;
@@ -956,7 +1009,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
     }
     // name
     UILabel *nameLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-        70.0, 2.0, 230.0, 25.0)];
+      70.0, 2.0, 230.0, 25.0)];
     nameLabel.font = [UIFont boldSystemFontOfSize:14.0];
     nameLabel.textAlignment = kTextAlignmentLeft;
     nameLabel.textColor = [UIColor blackColor];
@@ -964,7 +1017,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
     [cell.contentView addSubview:nameLabel];
     // size
     UILabel *sizeLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-        70.0, 26.0, 110.0, 16.0)];
+      70.0, 26.0, 110.0, 16.0)];
     sizeLabel.font = [UIFont boldSystemFontOfSize:12.0];
     sizeLabel.textAlignment = kTextAlignmentLeft;
     sizeLabel.textColor = [UIColor blackColor];
@@ -973,7 +1026,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
     // datetime
     if (product.datetime) {
       UILabel *dateLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-          175.0, 27.0, 100.0, 16.0)];
+        175.0, 27.0, 100.0, 16.0)];
       dateLabel.font = [UIFont systemFontOfSize:12.0];
       dateLabel.textAlignment = kTextAlignmentLeft;
       dateLabel.textColor = [UIColor grayColor];
@@ -982,7 +1035,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
     }
     // price
     UILabel *priceLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-        70.0, 45.0, 60.0, 16.0)];
+      70.0, 45.0, 60.0, 16.0)];
     priceLabel.font = [UIFont systemFontOfSize:12.0];
     priceLabel.textAlignment = kTextAlignmentLeft;
     priceLabel.textColor = [UIColor grayColor];
@@ -993,7 +1046,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
     [cell.contentView addSubview:priceLabel];
     // deduction
     UILabel *deductionLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-        125.0, 45.0, 60.0, 16.0)];
+      125.0, 45.0, 60.0, 16.0)];
     deductionLabel.font = [UIFont systemFontOfSize:12.0];
     deductionLabel.textAlignment = kTextAlignmentLeft;
     deductionLabel.textColor = [UIColor grayColor];
@@ -1004,7 +1057,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
     [cell.contentView addSubview:deductionLabel];
     // category
     UILabel *categoryLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-        176.0, 45.0, 190.0, 16.0)];
+      176.0, 45.0, 190.0, 16.0)];
     categoryLabel.font = [UIFont systemFontOfSize:12.0];
     categoryLabel.textAlignment = kTextAlignmentLeft;
     categoryLabel.textColor = [UIColor grayColor];
@@ -1012,7 +1065,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
     [cell.contentView addSubview:categoryLabel];
     // ean
     UILabel *eanLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-        70.0, 62.0, 110.0, 16.0)];
+      70.0, 62.0, 110.0, 16.0)];
     eanLabel.font = [UIFont systemFontOfSize:12.0];
     eanLabel.textAlignment = kTextAlignmentLeft;
     eanLabel.textColor = [UIColor grayColor];
@@ -1020,7 +1073,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
     [cell.contentView addSubview:eanLabel];
     // expires_at
     UILabel *expiresAtLabel = [[UILabel alloc] initWithFrame:CGRectMake(
-        175.0, 62.0, 100.0, 16.0)];
+      175.0, 62.0, 100.0, 16.0)];
     expiresAtLabel.textAlignment = kTextAlignmentLeft;
     expiresAtLabel.tag = 7;
     if (product.expiresAt && [product.expiresAt length] != 0) {

--- a/Generika/Receipt.h
+++ b/Generika/Receipt.h
@@ -59,6 +59,7 @@
 @interface Receipt : NSObject <NSCoding>
 
 @property (nonatomic, strong, readwrite) NSString *amkfile;
+@property (nonatomic, strong, readwrite) NSString *filename;
 @property (nonatomic, strong, readwrite) NSString *datetime;
 
 @property (nonatomic, strong, readwrite) NSString *hashedKey;
@@ -67,8 +68,9 @@
 @property (nonatomic, strong, readwrite) Patient *patient;
 @property (nonatomic, strong, readwrite) NSArray *products;
 
-@property (nonatomic, strong, readwrite) NSString *issuedPlace;
-@property (nonatomic, strong, readwrite) NSString *issuedDate;
+@property (nonatomic, strong, readonly) NSString *issuedDate;
+@property (nonatomic, strong, readonly) NSString *issuedPlace;
+@property (nonatomic, strong, readonly) NSString *importedAt;
 
 + (NSDictionary *)rereiptKeyMaps;
 + (id)importFromDict:(NSDictionary *)dict;

--- a/Generika/ReceiptManager.m
+++ b/Generika/ReceiptManager.m
@@ -128,7 +128,7 @@ static ReceiptManager *_sharedInstance = nil;
   // import .amk receipt file.
   NSData *now = [NSDate date];
   NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
-  [dateFormat setDateFormat:@"HH:mm dd.MM.YY"];
+  [dateFormat setDateFormat:@"HH:mm:ss dd.MM.YYYY"];
   NSString *datetime = [dateFormat stringFromDate:now];
   NSString *fileName = [[url absoluteString] lastPathComponent];
 
@@ -211,6 +211,7 @@ static ReceiptManager *_sharedInstance = nil;
   receipt = [Receipt importFromDict:receiptDict];
   // additional values
   [receipt setValue:amkfile forKey:@"amkfile"];
+  [receipt setValue:fileName forKey:@"filename"];
   [receipt setValue:datetime forKey:@"datetime"];
 
   return receipt;
@@ -235,7 +236,7 @@ static ReceiptManager *_sharedInstance = nil;
                           attributes:nil
                                error:&error];
   if (error) { return nil; }
-  // create file `RZ_timestamp.amk`
+  // create file as new name `RZ_timestamp.amk`
   time_t timestamp = (time_t)[[NSDate date] timeIntervalSince1970];
   NSString *amkFile = [NSString stringWithFormat:
     @"%@_%d.amk", @"RZ", (int)timestamp];


### PR DESCRIPTION
Add recent changes (See each commit messages about details):

* Add iCloud File Importer
* Add original filename label (Receipt list view cell)
* Change date format same as Amiko exported `place_date`. (**required old receipt deletion**)
* Add `importedAt` property using datetime (Receipt)
* Fix table view cell layout on iPhone SE
* Add label frame size expasnion on landscape (for small size display like SE)
* Add importing alerts for success import (both, file loading from iCloud and opening file with Safari, Email etc.)
* Fix plural label name `1 Medikamente` as `1 Medikament`
* Add product counts on Receipt Detail View Header (like `Medikamente (6)`)
* Fix job title label for Artzt
* Update Receipt Action sheet title (Add original filename and datetime)

\# this pull request is just a notification marked as `merge ready` (`master` to `master`)