### PR TITLE
Fix view layouts on ReceiptView

### DIFF
--- a/Generika.xcodeproj/project.pbxproj
+++ b/Generika.xcodeproj/project.pbxproj
@@ -631,6 +631,8 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				DEBUG_ACTIVITY_MODE = "";
+				"DEBUG_ACTIVITY_MODE[arch=*]" = disable;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -685,6 +687,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				DEBUG_ACTIVITY_MODE = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -897,6 +900,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				COPY_PHASE_STRIP = YES;
+				DEBUG_ACTIVITY_MODE = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_C_LANGUAGE_STANDARD = gnu99;

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ ifeq (, $(OS_VERSION))
 	OS_VERSION=latest
 endif
 
+build:
+	xcodebuild -workspace Generika.xcworkspace -scheme Generika
+.PHONY: build
+
 test:
 	OS_VERSION=$(OS_VERSION) ./bin/test-runner All
 .PHONY: test


### PR DESCRIPTION
My master branch is merge ready for new release.

### Fix label's width on cell in receipt table view. (Medikamente Sektion)

After some rotation, wrong (at previous device rotation mode) width value for height calculation was given. The main purpose of this pull request is this fixing on receipt view.

And this has also some following changes.

* Refactoring for label making and view layouts
* Add `make build` as utility (as we talked in chat)
* Disable intrusive log messages about `OS_ACTIVITY_MODE` at debug (only DEBUG)